### PR TITLE
 Allow templating HTML in source files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,25 +108,32 @@ To make a new project with the defualt configuration run the `init` subcommand.
 The default configuration looks similar to below:
 
 ```toml
-# raven.toml
-
 source = "src"
 dest = "dest"
 syntaxes = "syntaxes"
 syntax_theme = "base16-eighties.dark"
 custom_syntax_themes = "syntax-themes"
-default_favicon = "favicon.png"
+default_favicon = "favicon.ico"
+default_style = "style.css"
+default_template = "template.html"
+process_html = true
+
+# Optional
+template_source_html = true
 ```
 
-| Name                   | Description                                               |
-| ---------------------- | --------------------------------------------------------- |
-| `source`               | Where Markdown source files are stored                    |
-| `dest`                 | Where generated HTML files are stored                     |
-| `syntaxes`             | Where additional syntax highliting files are stored       |
-| `syntax_theme`         | The syntax highlighting theme to use                      |
-| `custom_syntax_themes` | Where custom syntax highlighting themes are stored        |
-| `default_favicon`      | The defualt favxicon used for files that don't supply one |
-| `process_html`         | If generated HTML should be processed (minimized, etc.)   |
+| Field                  | Description                                                               | Required? |
+| ---------------------- | ------------------------------------------------------------------------- | --------- |
+| `source`               | Where Markdown source files are stored                                    | Yes       |
+| `dest`                 | Where generated HTML files are stored                                     | Yes       |
+| `syntaxes`             | Where additional syntax highliting files are stored                       | Yes       |
+| `syntax_theme`         | The syntax highlighting theme to use                                      | Yes       |
+| `custom_syntax_themes` | Where custom syntax highlighting themes are stored                        | Yes       |
+| `default_favicon`      | The defualt favicon used for files that don't supply one                  | Yes       |
+| `default_style`        | The default CSS stylesheet used for files that don't specify one          | Yes       |
+| `default_template`     | The default HTML template used for files that don't specify one           | Yes       |
+| `process_html`         | If generated HTML should be processed (minimized, etc.)                   | Yes       |
+| `template_source_html` | Wether to allow usage of templating in HTML files in the source directory | No        |
 
 The defualt syntax themes are as follows:
 - `base16-ocean.dark`
@@ -147,20 +154,25 @@ In each markdown file a code block with the language specifier `pageinfo` is req
 ```pageinfo
 title = "Hello, World"
 description = "Greet the world"
-style = "style.css"
-template = "template.html"
 
 # optional
+style = "style.css"
+template = "template.html"
 favicon = favicon.ico
 ```
 ````
 
-The first two items here are self-explainatory. `style` is the stylesheet to be embeded into the HTML document.
-It's path is relative to the `raven.toml` at the root of the project, the same thing is true in regard to the `template` and `favicon` keys.
-`template` is the HTML template to embed the generated HTML into, each document can use whichever template that is available.
-`favicon` is optional: if it's omitted, or the file isn't found, then the generated HTML doesn't have a favicon.
-The favicon is encoded in base64 and stored using a data url in the generated HTML.
-The favicon is not copied to the configured destination directory.
+| Field         | Description                                           | Required |
+| ------------- | ----------------------------------------------------- | -------- |
+| `title`       | The title of the page                                 | Yes      |
+| `description` | The description of the page                           | Yes      |
+| `style`       | The CSS stylesheet to use. This overrides the default | No       |
+| `template`    | The HTML template to use. This overrides the default  | No       |
+| `favicon`     | The favicon image to use for the page                 | No       |
+
+The favicon and stylesheet are embeded into the HTML document.
+The favicon is encoded in base64 and stored using a data url in the generated HTML, it is not copied to the destination directory.
+The paths for all the fields are relative to the `raven.toml` at the root of the project.
 
 ### Considerations
 

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ favicon = favicon.ico
 | ------------- | ----------------------------------------------------- | -------- |
 | `title`       | The title of the page                                 | Yes      |
 | `description` | The description of the page                           | Yes      |
-| `style`       | The CSS stylesheet to use. This overrides the default | No       |
-| `template`    | The HTML template to use. This overrides the default  | No       |
+| `style`       | The CSS stylesheet to use, this overrides the default | No       |
+| `template`    | The HTML template to use, this overrides the default  | No       |
 | `favicon`     | The favicon image to use for the page                 | No       |
 
 The favicon and stylesheet are embeded into the HTML document.
@@ -180,4 +180,5 @@ The paths for all the fields are relative to the `raven.toml` at the root of the
 
 - Markdown files (`.md` or `.markdown`) in the configured source directory will be parsed and generated into HTML files in the configured destination directory.
 - HTML files (`.html` or `.htm`) in the configured source directory will be copied to the configured destination deirectory (after, if enabled, processing).
+- CSS file (`.css`) in the configured source directory will be copied to the configured destination directory.
 - Everything else in the configured source directory gets ignored.

--- a/README.md
+++ b/README.md
@@ -180,5 +180,5 @@ The paths for all the fields are relative to the `raven.toml` at the root of the
 
 - Markdown files (`.md` or `.markdown`) in the configured source directory will be parsed and generated into HTML files in the configured destination directory.
 - HTML files (`.html` or `.htm`) in the configured source directory will be copied to the configured destination deirectory (after, if enabled, processing).
-- CSS file (`.css`) in the configured source directory will be copied to the configured destination directory.
+- CSS files (`.css`) in the configured source directory will be copied to the configured destination directory.
 - Everything else in the configured source directory gets ignored.

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -36,13 +36,21 @@ fn benchmark_integrate_html_into_template(c: &mut Criterion)
         .remove(&config.syntax_theme)
         .unwrap();
     let assets: Arc<DashMap<PathBuf, String>> = Arc::new(DashMap::new());
-    let site = Website::new(config, SyntaxSet::load_defaults_newlines(), assets, theme);
+    let site = Website::new(config.clone(), SyntaxSet::load_defaults_newlines(), assets, theme);
     let markdown = DEFAULT_MD_BENCHMARK_SRC;
     let (html, page_info) = site
         .parse_markdown(black_box(markdown.to_string()), PathBuf::new())
         .unwrap();
-    std::fs::write(&page_info.style, defaults::DEFAULT_CSS_STYLESHEET_SRC).unwrap();
-    std::fs::write(&page_info.template, defaults::DEFAULT_HTML_TEMPLATE_SRC).unwrap();
+    let stylesheet = match page_info.style.clone() {
+        Some(x) => x,
+        None => config.default_style.clone(),
+    };
+    let template = match page_info.template.clone() {
+        Some(x) => x,
+        None => config.default_template.clone(),
+    };
+    std::fs::write(&stylesheet, defaults::DEFAULT_CSS_STYLESHEET_SRC).unwrap();
+    std::fs::write(&template, defaults::DEFAULT_HTML_TEMPLATE_SRC).unwrap();
 
     let exe = tokio::runtime::Runtime::new().unwrap();
     let mut group = c.benchmark_group("throughput");

--- a/src/build.rs
+++ b/src/build.rs
@@ -331,6 +331,53 @@ impl Website
         Ok((html_out, page_info))
     }
 
+    async fn get_stylesheet(&self, stylesheet: PathBuf) -> Result<String>
+    {
+        // Read the stylesheet and wrap it in html
+        let stylesheet_path = stylesheet.canonicalize().unwrap_or(stylesheet);
+        let stylesheet = if let Some(contents) = self.assets.get(&stylesheet_path) {
+            contents.clone()
+        }
+        else {
+            let stylesheet = format!(
+                "<style>{}</style>",
+                fs::read_to_string(&stylesheet_path).await.map_err(|e| {
+                    Error::Io {
+                        err:  e,
+                        path: stylesheet_path.clone(),
+                    }
+                })?
+            );
+            self.assets.insert(stylesheet_path, stylesheet.clone());
+            stylesheet
+        };
+        Ok(stylesheet)
+    }
+
+    async fn get_favicon(&self, favicon: PathBuf) -> Result<String>
+    {
+        let favicon_path = favicon.canonicalize().unwrap_or(favicon);
+        let favicon_encoded = if let Some(contents) = self.assets.get(&favicon_path) {
+            contents.clone()
+        }
+        else {
+            // If the favicon isn't found then one isn't inserted.
+            let encoded = if favicon_path.is_file() {
+                let b64 = read_to_base64_string(favicon_path.clone()).await?;
+                // Base64 encode the favicon and wrap it in the icon HTML
+                format!("<link rel=\"icon\" type=\"image/x-icon\" href=\"data:image/x-icon;base64,{b64}\">",)
+            }
+            else {
+                String::new()
+            };
+
+            self.assets.insert(favicon_path, encoded.clone());
+            encoded
+        };
+
+        Ok(favicon_encoded)
+    }
+
     pub async fn make_html_from_md(
         &self,
         source_file: (PathBuf, String),
@@ -352,28 +399,31 @@ impl Website
             .skip_while(|x| *x != here.file_name().unwrap())
             .skip(2)
             .collect::<PathBuf>();
-        let dest_path = config
-            .dest
-            .join(source_path_stem.parent().unwrap_or(&source_path_stem))
-            .join(format!("{}.html", source_file_name.to_string_lossy()));
+        let dest_dir = config.dest.join(source_path_stem.parent().unwrap_or(&source_path_stem));
 
         match &*source_file_extention {
             "md" | "markdown" => (),
-            "html" | "htm" => {
-                let html = fs::read_to_string(&source_file).await.map_err(|e| {
+            "css" | "html" | "htm" => {
+                let mut contents = fs::read_to_string(&source_file).await.map_err(|e| {
                     Error::Io {
                         err:  e,
-                        path: source_file,
+                        path: source_file.clone(),
                     }
                 })?;
 
                 // Perform final actions on html
-                let html = post_process_html(html)?;
+                if source_file_extention != "css" {
+                    let stylesheet = self.get_stylesheet(config.default_style.clone()).await?;
+                    let favicon = self.get_favicon(config.default_favicon.clone()).await?;
+                    apply_to_template(&mut contents, None, None, favicon, stylesheet);
+                    contents = post_process_html(contents)?;
+                }
 
-                fs::write(&dest_path, html).await.map_err(|e| {
+                let dest_file = dest_dir.join(source_file.file_name().unwrap());
+                fs::write(&dest_file, contents).await.map_err(|e| {
                     Error::Io {
                         err:  e,
-                        path: dest_path,
+                        path: dest_file,
                     }
                 })?;
 
@@ -382,9 +432,11 @@ impl Website
             _ => return Ok(()),
         }
 
+        let dest_file = dest_dir.join(format!("{}.html", source_file_name.to_string_lossy()));
+
         // If the destination exists, and the source is more recent'ly modified than the
         // destination, then we skip generating this file.
-        if !rebuild_all && !should_regenerate_file(&source_file, &dest_path)? {
+        if !rebuild_all && !should_regenerate_file(&source_file, &dest_file)? {
             return Ok(());
         }
 
@@ -402,7 +454,7 @@ impl Website
         };
 
         // Create the parent dir in the destination path
-        let dest_path_parent = dest_path.parent().unwrap_or(&dest_path);
+        let dest_path_parent = dest_file.parent().unwrap_or(&dest_file);
         if !dest_path_parent.exists() {
             fs::create_dir_all(dest_path_parent).await.map_err(|e| {
                 Error::Io {
@@ -416,10 +468,10 @@ impl Website
         let html = post_process_html(html)?;
 
         // Write out the file
-        Error::unwrap_gracefully(fs::write(&dest_path, html).await.map_err(|e| {
+        Error::unwrap_gracefully(fs::write(&dest_file, html).await.map_err(|e| {
             Error::Io {
                 err:  e,
-                path: dest_path,
+                path: dest_file,
             }
         }));
 
@@ -434,7 +486,6 @@ impl Website
         html: String,
     ) -> Result<String>
     {
-        let assets = self.assets.clone();
         let config = &self.config;
         let stylesheet = match page_info.style.clone() {
             Some(x) => x,
@@ -460,44 +511,8 @@ impl Website
             .clone()
             .unwrap_or(PathBuf::from(&config.default_favicon));
         let favicon_path = favicon_path.canonicalize().unwrap_or(favicon_path);
-        let favicon_encoded = if let Some(contents) = assets.get(&favicon_path) {
-            contents.clone()
-        }
-        else {
-            // If the favicon isn't found then one isn't inserted.
-            let b64 = if favicon_path.is_file() {
-                read_to_base64_string(favicon_path.clone()).await?
-            }
-            else {
-                String::new()
-            };
-            // Base64 encode the favicon and wrap it in the icon HTML
-            let encoded = format!("<link rel=\"icon\" type=\"image/x-icon\" href=\"data:image/x-icon;base64,{b64}\">",);
-
-            assets.insert(favicon_path, encoded.clone());
-            encoded
-        };
-
-
-        // Read the stylesheet and wrap it in html
-        let stylesheet_path = stylesheet.canonicalize().unwrap_or(stylesheet);
-        let stylesheet = if let Some(contents) = assets.get(&stylesheet_path) {
-            contents.clone()
-        }
-        else {
-            let stylesheet = format!(
-                "<style>{}</style>",
-                fs::read_to_string(&stylesheet_path).await.map_err(|e| {
-                    Error::Io {
-                        err:  e,
-                        path: stylesheet_path.clone(),
-                    }
-                })?
-            );
-
-            assets.insert(stylesheet_path, stylesheet.clone());
-            stylesheet
-        };
+        let favicon = self.get_favicon(favicon_path).await?;
+        let stylesheet = self.get_stylesheet(stylesheet).await?;
 
         // Add the markdown html into the template html, then write it out.
         let mut template = Error::unwrap_gracefully(fs::read_to_string(&template).await.map_err(|e| {
@@ -507,10 +522,11 @@ impl Website
             }
         }));
 
-        apply_to_template(&mut template, Some(html), Some(page_info), favicon_encoded, stylesheet);
+        apply_to_template(&mut template, Some(html), Some(page_info), favicon, stylesheet);
         Ok(template)
     }
 }
+
 
 fn apply_to_template(
     template: &mut String,
@@ -520,18 +536,14 @@ fn apply_to_template(
     stylesheet: String,
 )
 {
-    html.and_then(|html| {
-        Some({
-            *template = template.replace(TEMPLATE_NAME_BODY, html.as_ref());
-        })
-    });
-    page_info.and_then(|page_info| {
-        Some({
-            *template = template
-                .replace(TEMPLATE_NAME_TITLE, &page_info.title)
-                .replace(TEMPLATE_NAME_DESC, &page_info.description);
-        })
-    });
+    if let Some(html) = html {
+        *template = template.replace(TEMPLATE_NAME_BODY, html.as_ref());
+    }
+    if let Some(page_info) = page_info {
+        *template = template
+            .replace(TEMPLATE_NAME_TITLE, &page_info.title)
+            .replace(TEMPLATE_NAME_DESC, &page_info.description);
+    }
     *template = template
         .replace(TEMPLATE_NAME_FAVICON, &favicon)
         .replace(TEMPLATE_NAME_STYLESHEET, &stylesheet);

--- a/src/config.rs
+++ b/src/config.rs
@@ -35,8 +35,17 @@ pub struct Config
     /// The default favicon for webpages.
     pub default_favicon: PathBuf,
 
+    /// The default css stylesheet for webpages.
+    pub default_style: PathBuf,
+
+    /// The default HTML template for webpages.
+    pub default_template: PathBuf,
+
     /// If generated HTML should be processed (minimized, etc.)
     pub process_html: bool,
+
+    /// Treat html found in the source directory as a template
+    pub template_source_html: Option<bool>,
 }
 
 impl Default for Config
@@ -51,6 +60,9 @@ impl Default for Config
             syntax_theme:         String::from(Self::DEFAULT_SYNTAX_THEME),
             default_favicon:      PathBuf::from(Self::DEFAULT_FAVICON_FILE),
             custom_syntax_themes: PathBuf::from(Self::DEFAULT_CUSTOM_SYNTAX_THEMES_DIR),
+            template_source_html: None,
+            default_style:        PathBuf::from(Self::DEFUALT_STYLE_FILE),
+            default_template:     PathBuf::from(Self::DEFAULT_TEMPLATE_FILE),
         }
     }
 }
@@ -65,6 +77,8 @@ impl Config
     const DEFAULT_SRC_DIR: &str = "src";
     const DEFAULT_SYNTAXES_DIR: &str = "syntaxes";
     const DEFAULT_SYNTAX_THEME: &str = "base16-eighties.dark";
+    const DEFAULT_TEMPLATE_FILE: &str = "template.html";
+    const DEFUALT_STYLE_FILE: &str = "style.css";
 
     pub fn from_toml(path: &PathBuf) -> Result<Self>
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,10 +23,10 @@ pub struct PageInfo
     pub description: String,
 
     /// The CSS stylesheet to use.
-    pub style: PathBuf,
+    pub style: Option<PathBuf>,
 
     /// The path to the HTML template to use.
-    pub template: PathBuf,
+    pub template: Option<PathBuf>,
 
     /// Use a different favicon for this page. If omitted the defualt one will
     /// be used.


### PR DESCRIPTION
* Make `style` and `template` optional and add default fields into the configuration file in order to support these features in html files.
* Update documentation
* Split some things out into functions